### PR TITLE
ReferenceError: process is not defined (Part II)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | Statements                                                                                      | Branches                                                                                 | Functions                                                                                     | Lines                                                                                 |
 | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| ![Statements](https://img.shields.io/badge/statements-87.96%25-yellow.svg?style=flat&logo=jest) | ![Branches](https://img.shields.io/badge/branches-72.5%25-red.svg?style=flat&logo=jest) | ![Functions](https://img.shields.io/badge/functions-81.81%25-yellow.svg?style=flat&logo=jest) | ![Lines](https://img.shields.io/badge/lines-88.65%25-yellow.svg?style=flat&logo=jest) |
+| ![Statements](https://img.shields.io/badge/statements-87.38%25-yellow.svg?style=flat&logo=jest) | ![Branches](https://img.shields.io/badge/branches-72.5%25-red.svg?style=flat&logo=jest) | ![Functions](https://img.shields.io/badge/functions-81.81%25-yellow.svg?style=flat&logo=jest) | ![Lines](https://img.shields.io/badge/lines-88%25-yellow.svg?style=flat&logo=jest) |
 
 ## Table of Contents
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,12 @@ export const jsDownload = (
 export default function useDownloader(
   options: UseDownloaderOptions = {}
 ): UseDownloader {
-  const debugMode = process ? !!process?.env?.REACT_APP_DEBUG_MODE : false;
+  let debugMode = false;
+  try {
+      debugMode = process ? !!process?.env?.REACT_APP_DEBUG_MODE : false;
+  } catch {
+    debugMode = false;
+  }
 
   const [elapsed, setElapsed] = useState(0);
   const [percentage, setPercentage] = useState(0);


### PR DESCRIPTION
I'm still getting the process is not defined error using 1.2.5.

Implementing akin to how MarcoRS had proposed fixes for me

              still errors when it tries to access process. This worked for me : 
```
  let debugMode = false;
  try {
    if (process) {
      debugMode = !!process?.env?.REACT_APP_DEBUG_MODE;
    }
  } catch (err) {
    //Your error handling
  }
```

_Originally posted by @MarcosRS in https://github.com/the-bugging/react-use-downloader/issues/17#issuecomment-1936659505_
            
