### PR TITLE
Introduce overrideOptions and progress JSDocs annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ export default function App() {
 
 - An object with the following keys:
 
-| key          | description                      | arguments                                                 |
-| ------------ | -------------------------------- | --------------------------------------------------------- |
-| size         | size in bytes                    | n/a                                                       |
-| elapsed      | elapsed time in seconds          | n/a                                                       |
-| percentage   | percentage in string             | n/a                                                       |
-| download     | download function handler        | (downloadUrl: string, filename: string, timeout?: number) |
-| cancel       | cancel function handler          | n/a                                                       |
-| error        | error object from the request    | n/a                                                       |
-| isInProgress | boolean denoting download status | n/a                                                       |
+| key          | description                      | arguments                                                                                         |
+| ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| size         | size in bytes                    | n/a                                                                                               |
+| elapsed      | elapsed time in seconds          | n/a                                                                                               |
+| percentage   | percentage in string             | n/a                                                                                               |
+| download     | download function handler        | (downloadUrl: string, filename: string, timeout?: number, overrideOptions?: UseDownloaderOptions) |
+| cancel       | cancel function handler          | n/a                                                                                               |
+| error        | error object from the request    | n/a                                                                                               |
+| isInProgress | boolean denoting download status | n/a                                                                                               |
 
 ```jsx
 const { size, elapsed, percentage, download, cancel, error, isInProgress } =

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,12 @@ export type ErrorMessage = {
   errorMessage: string;
 } | null;
 
+/**
+ * Initiate the download of the specified asset from the specified url. Optionally supply timeout and overrideOptions.
+ * @example await download('https://example.com/file.zip', 'file.zip')
+ * @example await download('https://example.com/file.zip', 'file.zip', 500) timeouts after 500ms
+ * @example await download('https://example.com/file.zip', 'file.zip', undefined, { method: 'GET' }) skips optional timeout but supplies overrideOptions
+ */
 export type DownloadFunction = (
   /** Download url
    * @example https://upload.wikimedia.org/wikipedia/commons/4/4d/%D0%93%D0%BE%D0%B2%D0%B5%D1%80%D0%BB%D0%B0_%D1%96_%D0%9F%D0%B5%D1%82%D1%80%D0%BE%D1%81_%D0%B2_%D0%BF%D1%80%D0%BE%D0%BC%D1%96%D0%BD%D1%8F%D1%85_%D0%B2%D1%80%D0%B0%D0%BD%D1%96%D1%88%D0%BD%D1%8C%D0%BE%D0%B3%D0%BE_%D1%81%D0%BE%D0%BD%D1%86%D1%8F.jpg
@@ -14,9 +20,23 @@ export type DownloadFunction = (
    */
   filename: string,
   /** Optional timeout to download items */
-  timeout?: number
+  timeout?: number,
+  /** Optional options to supplement and/or override UseDownloader options  */
+  overrideOptions?: UseDownloaderOptions
 ) => Promise<void | null>;
 
+/**
+ * Provides access to Downloader functionality and settings.
+ *
+ * @interface EditDialogField
+ * @field {number} size in bytes.
+ * @field {number} elapsed time in seconds.
+ * @field {number} percentage in string
+ * @field {DownloadFunction} download function handler
+ * @field {void} cancel function handler
+ * @field {ErrorMessage} error object from the request
+ * @field {boolean} isInProgress boolean flag denoting download status
+ */
 export interface UseDownloader {
   /** Size in bytes */
   size: number;


### PR DESCRIPTION
Proposal to handle #25

No change to existing consumers; continue using only the useDownloader initialisation unaffected, but this PR allows overrideOptions to be specified on the download invocation as well.

`await download(DOWNLOAD_ROOT_URI + fileUrl, saveAs, undefined, { method: 'POST' });`

Works for my scenario, should sort you as well @davecarlson (this is where I was heading on my PR last night anyhow; hope it works for you too - and ofc is acceptable to @olavoparno)
